### PR TITLE
Custom filter provider to support any extension filters

### DIFF
--- a/Hangfire.Server/Startup.cs
+++ b/Hangfire.Server/Startup.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using Hangfire.Common;
 using Hangfire.SqlServer;
 using Interface;
 using Microsoft.AspNetCore.Builder;
@@ -21,6 +22,9 @@ namespace Hangfire.Server
         public void ConfigureServices(IServiceCollection services)
         {
             ConfigurePluginAssemblies(services);
+
+            JobFilterProviders.Providers.Add(new CustomJobFilterProvider());
+
             services.AddHangfire(opt => opt
             .SetDataCompatibilityLevel(CompatibilityLevel.Version_170)
             .UseColouredConsoleLogProvider()

--- a/Hangfire.Server/Startup.cs
+++ b/Hangfire.Server/Startup.cs
@@ -37,7 +37,8 @@ namespace Hangfire.Server
            })
            );
 
-            services.AddHangfireServer();
+            services.AddHangfireServer(options =>
+                options.Queues = new [] { "critical", "default", "low" });
 
             services.AddSingleton<IDispatcherRegistry>(provider =>
             {

--- a/HangfireClient/Program.cs
+++ b/HangfireClient/Program.cs
@@ -25,13 +25,14 @@ namespace HangfireClient
                     DisableGlobalLocks = true
                 });
 
-     
-
             IBackgroundJobClient client = new BackgroundJobClient();
             IState state = new EnqueuedState();
 
-            client.Enqueue<EbmCoreService>(x => x.Execute("business/sleep", null));
+            client.Enqueue<EbmCoreService>(x => x.Execute(
+                new CustomJob("business/sleep", "low")));
 
+            client.Enqueue<EbmCoreService>(x => x.Execute(
+                new CustomJob("business/sleep", "critical")));
         }
     }
 }

--- a/HangfireClient/Program.cs
+++ b/HangfireClient/Program.cs
@@ -4,6 +4,7 @@ using Hangfire.SqlServer;
 using Hangfire.States;
 using Interface;
 using System;
+using Hangfire.Common;
 
 namespace HangfireClient
 {
@@ -25,14 +26,16 @@ namespace HangfireClient
                     DisableGlobalLocks = true
                 });
 
+            JobFilterProviders.Providers.Add(new CustomJobFilterProvider());
+
             IBackgroundJobClient client = new BackgroundJobClient();
             IState state = new EnqueuedState();
 
             client.Enqueue<EbmCoreService>(x => x.Execute(
-                new CustomJob("business/sleep", "low")));
+                new CustomJob("business/sleep", new Attribute[] { new QueueAttribute("low") })));
 
             client.Enqueue<EbmCoreService>(x => x.Execute(
-                new CustomJob("business/sleep", "critical")));
+                new CustomJob("business/sleep", new Attribute[] { new QueueAttribute("critical") })));
         }
     }
 }

--- a/Interface/EbmCoreService.cs
+++ b/Interface/EbmCoreService.cs
@@ -14,6 +14,7 @@ namespace Interface
             _registry = registry ?? throw new ArgumentNullException(nameof(registry));
         }
 
+        [CustomQueue]
         [DisplayName("EBM ({0})")]
         public void Execute(CustomJob job)
         {

--- a/Interface/EbmCoreService.cs
+++ b/Interface/EbmCoreService.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
+using Hangfire.Common;
+using Hangfire.States;
 
 namespace Interface
 {
@@ -13,10 +15,42 @@ namespace Interface
         }
 
         [DisplayName("EBM ({0})")]
-        public void Execute(string message, object[] args)
+        public void Execute(CustomJob job)
         {
-            var dispatcher = _registry.FindDispatcher(message);
-            dispatcher.Dispatch(args);
+            var dispatcher = _registry.FindDispatcher(job.Message);
+            dispatcher.Dispatch(job.Args);
         }
+    }
+
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class CustomQueue : JobFilterAttribute, IElectStateFilter
+    {
+        public void OnStateElection(ElectStateContext context)
+        {
+            if (context.CandidateState is EnqueuedState enqueuedState)
+            {
+                foreach (object arg in context.BackgroundJob.Job.Args)
+                {
+                    if (arg is CustomJob customJob)
+                    {
+                        enqueuedState.Queue = customJob.Queue;
+                    }
+                }
+            }
+        }
+    }
+
+    public class CustomJob
+    {
+        public CustomJob(string message, string queue, params object[] args)
+        {
+            Message = message ?? throw new ArgumentNullException(nameof(message));
+            Queue = queue ?? throw new ArgumentNullException(nameof(queue));
+            Args = args ?? throw new ArgumentNullException(nameof(args));
+        }
+
+        public string Message { get; }
+        public string Queue { get; }
+        public object[] Args { get; }
     }
 }

--- a/Interface/Interface.csproj
+++ b/Interface/Interface.csproj
@@ -4,4 +4,8 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Hangfire.Core" Version="1.7.17" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
This PR adds a feature to use any extension filter (not only a custom queue as in the previous PR), which will now be stored as a part of a job and deserialised back when required. So extension filters are persisted as a part of `CustomJob` instance argument, and `CustomJobFilterProvider` knows how to get them back. But ensure both client and server use this job filter provider.